### PR TITLE
换用bibla-tex-gb7714-2015管理参考文献

### DIFF
--- a/bib/thesis.bib
+++ b/bib/thesis.bib
@@ -1,24 +1,23 @@
 %# -*- coding: utf-8-unix -*-
 
 @book{Meta_CN,
-  title = {{电磁超介质及其应用}},
+  title = {电磁超介质及其应用},
   address = {北京},
   publisher = {国防工业出版社},
   year = {2008},
-  author = {崔万照 and 马伟 and 邱乐徳 and 张洪太},
-  language = {chinese}
+  author = {崔万照 and 马伟 and 邱乐徳 and 张洪太}
 }
 
 @book{JohnD,
-  title = {{Photonic Crystals: Molding the Flow of Light}},
+  title = {Photonic Crystals: Molding the Flow of Light},
   publisher = {Princeton University Press},
   year = {2008},
   author = {Joannopoulos, J. D. and Johnson, S. G. and Winn, J. N.}
 }
 
 @book{IEEE-1363,
-  author={{IEEE Std 1363-2000}},
-  title={{IEEE} Standard Specifications for Public-Key Cryptography},
+  author={IEEE Std 1363-2000},
+  title={IEEE Standard Specifications for Public-Key Cryptography},
   address={New York},
   publisher={IEEE},
   year={2000}
@@ -26,7 +25,7 @@
 
 @article{chen2007act,
   author = {Chen, H. and Chan, C. T.},
-  title = {{Acoustic cloaking in three dimensions using acoustic metamaterials}},
+  title = {Acoustic cloaking in three dimensions using acoustic metamaterials},
   journal = {Applied Physics Letters},
   year = {2007},
   volume = {91},
@@ -36,7 +35,7 @@
 
 @article{chen2007ewi,
   author = {Chen, H. and Wu, B. I. and Zhang, B. and Kong, J. A.},
-  title = {{Electromagnetic Wave Interactions with a Metamaterial Cloak}},
+  title = {Electromagnetic Wave Interactions with a Metamaterial Cloak},
   journal = {Physical Review Letters},
   year = {2007},
   volume = {99},
@@ -83,7 +82,6 @@
   VOLUME = {2},
   SERIES = {新古文观止丛书},  
   ADDRESS = {武汉},
-  language = {chinese},
 }
 
 
@@ -93,8 +91,7 @@
   CHAPTER = {大人物还是讲人情的},
   PAGES = {185-207},
   PUBLISHER = {人民文学出版社},
-  YEAR = {2001},  
-  language = {chinese},
+  YEAR = {2001},
 }
 
 @book{tex,
@@ -180,7 +177,6 @@
   address =      {西安, 中国},
   publisher = {中国古籍出版社},
   month =        sep,
-  language =     {chinese},
 }
 
 @ARTICLE{cnarticle,
@@ -190,7 +186,6 @@
   PAGES =        {260--266},
   VOLUME =       224,
   YEAR =         1800,
-  LANGUAGE =         {chinese},
 }
 
 @thesis{zhubajie,
@@ -199,7 +194,6 @@
   school =       {广寒宫大学},
   year =         2005,
   address =      {北京},
-  language =     {chinese},
 }
 
 @thesis{shaheshang,
@@ -208,7 +202,6 @@
   school =       {清华大学},
   year =         2005,
   address =      {北京},
-  language =     {chinese},
 }
 
 @thesis{metamori2004,
@@ -222,7 +215,7 @@
 
 @thesis{FistSystem01,
   AUTHOR =       {Erez Zadok},
-  TITLE =        {{FiST: A System for Stackable File System Code Generation}},
+  TITLE =        {FiST: A System for Stackable File System Code Generation},
   YEAR =         2001,
   MONTH =        {May},
   SCHOOL =       {Computer Science Department, Columbia University},
@@ -240,10 +233,9 @@
 }
 
 @phdthesis{bai2008,
-	title={{信用风险传染模型和信用衍生品的定价}},
+	title={信用风险传染模型和信用衍生品的定价},
 	author={白云芬},
 	year={2008},
-	language={chinese},
 	school={上海交通大学},
 	address={上海},
 }
@@ -258,7 +250,6 @@
   modifydate =   {2001-12-19},
   citedate =     {2002-04-15},
   url =          {http://www.creader.com/news/20011219/200112190019.html},
-  language =     {chinese},
 }
 
 % 在线析出文献
@@ -278,7 +269,7 @@
         Address = {Vienna, Austria},
         Author = {{R Core Team}},
         Note = {{ISBN} 3-900051-07-0},
-        Organization = {{R Foundation for Statistical Computing}},
+        Organization = {R Foundation for Statistical Computing},
         title = {R: A Language and Environment for Statistical Computing},
         url = {http://www.R-project.org/},
         Year = {2012},

--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -61,7 +61,7 @@
 \RequirePackage{graphicx}
 \RequirePackage{subfigure}
 \RequirePackage{ccaption}
-\RequirePackage[backend=biber, style=caspervector,utf8, bibencoding=utf8, sorting=none]{biblatex}
+\RequirePackage[backend=biber,style=gb7714-2015]{biblatex}
 \RequirePackage{xcolor}
 \RequirePackage{wasysym}
 \RequirePackage{listings}


### PR DESCRIPTION
替换caspervector为gb7714-2015
bib文件中双层花括号会引起了编译错误，被修正了